### PR TITLE
Add Next.js skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Next.js Example
+
+This repo contains a minimal Next.js 14 project using TypeScript and TailwindCSS.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Note: Internet access is required to download dependencies.

--- a/nextjs-app/app/globals.css
+++ b/nextjs-app/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/nextjs-app/app/layout.tsx
+++ b/nextjs-app/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/nextjs-app/app/page.tsx
+++ b/nextjs-app/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1 className="text-4xl font-bold">Hello Next.js 14!</h1>
+    </main>
+  )
+}

--- a/nextjs-app/next-env.d.ts
+++ b/nextjs-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/nextjs-app/next.config.js
+++ b/nextjs-app/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "nextjs-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5"
+  }
+}

--- a/nextjs-app/postcss.config.js
+++ b/nextjs-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/nextjs-app/tailwind.config.js
+++ b/nextjs-app/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/nextjs-app/tsconfig.json
+++ b/nextjs-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a simple Next.js 14 project using TypeScript and TailwindCSS
- add instructions in README

## Testing
- `npm run dev` *(fails: `next` not found)*